### PR TITLE
handle more cases with var sub regex

### DIFF
--- a/jmu_gradescope_utils/jmu_test_case.py
+++ b/jmu_gradescope_utils/jmu_test_case.py
@@ -92,8 +92,8 @@ class _JmuTestCase(unittest.TestCase):
             if variables is not None:
 
                 for var in variables:
-                    regexp = '^(\s*){}\s*(?=\=)(?!==).*\n'.format(var)
-                    replace = "\\1{} = {}\n".format(var, repr(variables[var]))
+                    regexp = '(^|\n)( *){}\s*(?=\=)(?!==).*(\n|$)'.format(var)
+                    replace = "\\1\\2{} = {}\\3".format(var, repr(variables[var]))
                     new_file = re.sub(regexp, replace, new_file)
 
             with open(os.path.join(new_file_name), 'w') as f:


### PR DESCRIPTION
The original regex would only handle the first variable in a file, since it started with '^'.

This will handle an assignment on any line, and handle the beginning or end of the file correctly.

Caveat: It doesn't handle tab indentation.
