### PR TITLE
Fix: Correct two misspelled words found within library comments.

### DIFF
--- a/jmu_gradescope_utils/build_utils.py
+++ b/jmu_gradescope_utils/build_utils.py
@@ -58,7 +58,7 @@ def test_autograder(autograder_folder, sample_folder,
                              env=my_env)
         stdout, stderr = p.communicate()
         return_code = p.returncode
-        # Raise an excpeption of there was a problem so we can see the stack.
+        # Raise an exception if there was a problem so we can see the stack.
         if len(stdout) > 0:
             logging.error("stdout for run_tests.py:\n" + stdout.decode())
         if len(stderr) > 0:

--- a/jmu_gradescope_utils/data/template/tests/test_template.py
+++ b/jmu_gradescope_utils/data/template/tests/test_template.py
@@ -26,5 +26,5 @@ class TestDefault(JmuTestCase):
 
     @weight(8)
     def test_functionality(self):
-        """Test student code funtionality."""
+        """Test student code functionality."""
         self.assertEqual(1, 1)


### PR DESCRIPTION
These changes fix the spelling of two misspelled words found within comments defined within the library.

In `jmu_gradescope_utils/build_utils.py`, an inline comment has been updated to correct a misspelled word: `excpeption` to `exception`. Additionally, based on the context of the comment, `of` has been changed to `if`.

In `jmu_gradescope_utils/data/template/tests/test_template.py`, a method docstring has been updated to correct a misspelled word: `funtionality` to `functionality`.