### PR TITLE
make config.ini optional

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "JMU Python Gradescope Utils"
 copyright = "2020"
 author = "JMU People"
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx",'sphinx.ext.napoleon' ]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx", "sphinx.ext.napoleon"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 templates_path = ["_templates"]
 html_theme = "sphinx_rtd_theme"

--- a/scripts/jmu_gradescope_builder.py
+++ b/scripts/jmu_gradescope_builder.py
@@ -109,12 +109,12 @@ class App(tk.Tk):
 
         # Initialize text fields with current working directory
         self.grader_path_text.insert(1.0, os.getcwd())
-        self.grader_path_text.config(state=tk.DISABLED)
+#       self.grader_path_text.config(state=tk.DISABLED)
         if os.path.exists("config.ini"):
             self.sample_path_text.insert(1.0, os.getcwd() + os.path.sep + "sample")
         else:
             self.sample_path_text.insert(1.0, os.getcwd())
-        self.sample_path_text.config(state=tk.DISABLED)
+#       self.sample_path_text.config(state=tk.DISABLED)
 
         path_frame.pack(side=tk.TOP)
 
@@ -122,11 +122,11 @@ class App(tk.Tk):
         self.test_button = ttk.Button(button_frame, text='Test Autograder',
                                       command=self.test)
         self.test_button.pack(side=tk.LEFT, padx=4, pady=10)
-#        self.test_button["state"] = "disabled"
+#       self.test_button["state"] = "disabled"
 
         self.build_button = ttk.Button(button_frame, text='Build Autograder',
                                        command=self.build)
-#        self.build_button["state"] = "disabled"
+#       self.build_button["state"] = "disabled"
         self.build_button.pack(side=tk.LEFT, padx=4, pady=10)
 
         button_frame.pack(side=tk.TOP)
@@ -144,6 +144,7 @@ class App(tk.Tk):
     def test(self):
         autograder_folder = self.grader_path_text.get("1.0", 'end-1c')
         sample_folder = self.sample_path_text.get("1.0", 'end-1c')
+        os.chdir(autograder_folder)
         result_json_loc, code = build_utils.test_autograder(autograder_folder,
                                                             sample_folder)
         if code == 0:
@@ -155,6 +156,7 @@ class App(tk.Tk):
     def build(self):
         autograder_folder = self.grader_path_text.get("1.0", 'end-1c')
         autograder_path = Path(autograder_folder)
+        os.chdir(autograder_folder)
         name = 'autograder_' + str(autograder_path.name) + ".zip"
         zipfile = fd.asksaveasfilename(filetypes=[("Zip file", ".zip")],
                                        initialdir=autograder_folder,
@@ -169,7 +171,7 @@ class App(tk.Tk):
             self.grader_path_text.config(state=tk.NORMAL)
             self.grader_path_text.delete(1.0, "end")
             self.grader_path_text.insert(1.0, folder)
-            self.grader_path_text.config(state=tk.DISABLED)
+#           self.grader_path_text.config(state=tk.DISABLED)
 
             p = Path(folder)
             possible_sample = p / 'sample'
@@ -180,7 +182,7 @@ class App(tk.Tk):
             self.sample_path_text.config(state=tk.NORMAL)
             self.sample_path_text.delete(1.0, "end")
             self.sample_path_text.insert(1.0, str(possible_sample))
-            self.sample_path_text.config(state=tk.DISABLED)
+#           self.sample_path_text.config(state=tk.DISABLED)
 
     def select_new_autograder(self):
         dest = fd.askdirectory(title="Select Autograder Folder Location",
@@ -196,7 +198,7 @@ class App(tk.Tk):
             self.sample_path_text.config(state=tk.NORMAL)
             self.sample_path_text.delete(1.0, "end")
             self.sample_path_text.insert(1.0, folder)
-            self.sample_path_text.config(state=tk.DISABLED)
+#           self.sample_path_text.config(state=tk.DISABLED)
 
 
 if __name__ == "__main__":

--- a/scripts/jmu_gradescope_builder.py
+++ b/scripts/jmu_gradescope_builder.py
@@ -96,19 +96,25 @@ class App(tk.Tk):
         path_frame = ttk.Frame(self)
         path_frame.columnconfigure(0, weight=0)
         path_frame.columnconfigure(1, weight=1)
+
         label = ttk.Label(path_frame, text='Autograder:')
         label.grid(row=0, column=0, padx=4, pady=10, sticky="w")
-        self.grader_path_text = tk.Text(path_frame, height=1,
-                                        bg="gray95")
-
+        self.grader_path_text = tk.Text(path_frame, height=1, bg="gray95")
         self.grader_path_text.grid(row=0, column=1, padx=4, pady=10)
 
         label = ttk.Label(path_frame, text='Sample Submission:')
         label.grid(row=1, column=0, padx=4, pady=10, sticky="w")
-        self.sample_path_text = tk.Text(path_frame, height=1,
-                                        bg="gray95")
-        self.sample_path_text.grid(row=1, column=1, padx=4, pady=10,
-                                   sticky="w")
+        self.sample_path_text = tk.Text(path_frame, height=1, bg="gray95")
+        self.sample_path_text.grid(row=1, column=1, padx=4, pady=10, sticky="w")
+
+        # Initialize text fields with current working directory
+        self.grader_path_text.insert(1.0, os.getcwd())
+        self.grader_path_text.config(state=tk.DISABLED)
+        if os.path.exists("config.ini"):
+            self.sample_path_text.insert(1.0, os.getcwd() + os.path.sep + "sample")
+        else:
+            self.sample_path_text.insert(1.0, os.getcwd())
+        self.sample_path_text.config(state=tk.DISABLED)
 
         path_frame.pack(side=tk.TOP)
 
@@ -116,11 +122,11 @@ class App(tk.Tk):
         self.test_button = ttk.Button(button_frame, text='Test Autograder',
                                       command=self.test)
         self.test_button.pack(side=tk.LEFT, padx=4, pady=10)
-        self.test_button["state"] = "disabled"
+#        self.test_button["state"] = "disabled"
 
         self.build_button = ttk.Button(button_frame, text='Build Autograder',
                                        command=self.build)
-        self.build_button["state"] = "disabled"
+#        self.build_button["state"] = "disabled"
         self.build_button.pack(side=tk.LEFT, padx=4, pady=10)
 
         button_frame.pack(side=tk.TOP)
@@ -147,7 +153,6 @@ class App(tk.Tk):
             open_file(result_json_loc)
 
     def build(self):
-
         autograder_folder = self.grader_path_text.get("1.0", 'end-1c')
         autograder_path = Path(autograder_folder)
         name = 'autograder_' + str(autograder_path.name) + ".zip"
@@ -161,7 +166,6 @@ class App(tk.Tk):
         folder = fd.askdirectory(title='Select Autograder Folder')
         if len(folder) > 0:
             self.build_button["state"] = "enable"
-
             self.grader_path_text.config(state=tk.NORMAL)
             self.grader_path_text.delete(1.0, "end")
             self.grader_path_text.insert(1.0, folder)
@@ -169,19 +173,21 @@ class App(tk.Tk):
 
             p = Path(folder)
             possible_sample = p / 'sample'
-            if possible_sample.exists() and possible_sample.is_dir():
-                self.test_button["state"] = "enable"
-                self.sample_path_text.config(state=tk.NORMAL)
-                self.sample_path_text.delete(1.0, "end")
-                self.sample_path_text.insert(1.0, str(possible_sample))
-                self.sample_path_text.config(state=tk.DISABLED)
+            if not (possible_sample.exists() and possible_sample.is_dir()):
+                possible_sample = p
+
+            self.test_button["state"] = "enable"
+            self.sample_path_text.config(state=tk.NORMAL)
+            self.sample_path_text.delete(1.0, "end")
+            self.sample_path_text.insert(1.0, str(possible_sample))
+            self.sample_path_text.config(state=tk.DISABLED)
 
     def select_new_autograder(self):
         dest = fd.askdirectory(title="Select Autograder Folder Location",
                                mustexist=False)
         if len(dest) > 0:
             build_utils.create_template(dest)
-    
+
     def select_sample_submission(self):
         folder = fd.askdirectory(title='Select Sample Submission')
 


### PR DESCRIPTION
This PR adds two new features:

1. If no config.ini file is found, `build_zip` automatically generates one based on the *.py files in the autograder_folder.
2. The GUI automatically selects the current working directory by default. If now config.ini file is found, then the sample submission is assumed to be in the current working directory too.

This setup allows for smaller projects (Ex: HW and labs in CS 149) to have a simple folder structure. At a minimum, the project folder may contain two files (main.py and test_main.py, where "main" is any name) and no subfolders.